### PR TITLE
support expr_context Del  and use ExDict instead of Dict

### DIFF
--- a/test/test_call.py
+++ b/test/test_call.py
@@ -35,7 +35,6 @@ f(1, 2, *c, **d, **e)
 f(1, 2, *c)
 f(1, 2, y=1, *x, a=1, b=2, c=3, **d)
 f(1, 2, y=1, *x, a=1, b=2, c=3, **d, e=4)
-
 """
 
 res: Tag = to_tagged_ast(parse(code).result)

--- a/yapypy/extended_python/extended_ast.py
+++ b/yapypy/extended_python/extended_ast.py
@@ -1,0 +1,13 @@
+import ast
+import typing as t
+
+
+class ExDict(ast.Dict):
+    def __init__(self, keys: t.List[ast.expr], values: t.List[ast.expr],
+                 ctx: t.Union[ast.Store, ast.Load]):
+        super().__init__()
+        self.keys = keys
+        self.values = values
+        self.ctx = ctx
+
+    _fields = ('keys', 'values', 'ctx')

--- a/yapypy/extended_python/helper.py
+++ b/yapypy/extended_python/helper.py
@@ -1,7 +1,5 @@
 from rbnf.core.Tokenizer import Tokenizer
-import yapypy.extended_python.extended_ast as ex_ast
 import ast
-
 import typing as t
 
 

--- a/yapypy/extended_python/helper.py
+++ b/yapypy/extended_python/helper.py
@@ -1,26 +1,31 @@
 from rbnf.core.Tokenizer import Tokenizer
+import yapypy.extended_python.extended_ast as ex_ast
 import ast
+
 import typing as t
-store = ast.Store()
 
 
-class AsStore(ast.NodeVisitor):
-    def _store(self, node):
-        node.ctx = store
+class ExprContextFixer(ast.NodeVisitor):
+    def __init__(self, ctx):
+        self.ctx = ctx
+
+    def _store_simply(self, node):
+        node.ctx = self.ctx
+
+    def _store_recursively(self, node):
+        node.ctx = self.ctx
         self.generic_visit(node)
 
-    def visit_Name(self, node):
-        node.ctx = store
+    visit_Name = _store_simply
+    visit_Subscript = _store_simply
+    visit_Attribute = _store_simply
+    visit_Tuple = _store_recursively
+    visit_List = _store_recursively
+    visit_ExDict = _store_recursively
 
-    def visit_Subscript(self, node):
-        node.ctx = store
 
-    def visit_Attribute(self, node):
-        node.ctx = store
-
-    def _visit_seq(self, node):
-        node.ctx = store
-        self.generic_visit(node)
+_fix_store = ExprContextFixer(ast.Store()).visit
+_fix_del = ExprContextFixer(ast.Del()).visit
 
 
 class Loc:
@@ -41,12 +46,17 @@ class LocatedError(Exception):
 
 loc = Loc()
 
-_as_store = AsStore().visit
-
 
 def as_store(it):
     if hasattr(it, '_fields'):
-        _as_store(it)
+        _fix_store(it)
+        return it
+    return it
+
+
+def as_del(it):
+    if hasattr(it, '_fields'):
+        _fix_del(it)
         return it
     return it
 
@@ -215,6 +225,7 @@ def augassign_rewrite(it: Tokenizer):
 
 
 def expr_stmt_rewrite(lhs, ann, aug, aug_exp, rhs: t.Optional[list]):
+
     if rhs:
         as_store(lhs)
         *init, end = rhs
@@ -230,6 +241,8 @@ def expr_stmt_rewrite(lhs, ann, aug, aug_exp, rhs: t.Optional[list]):
     if aug_exp:
         as_store(lhs)
         return ast.AugAssign(lhs, aug(), aug_exp)
+
+    # NO AS STORE HERE!
     return ast.Expr(lhs)
 
 

--- a/yapypy/extended_python/parser.py
+++ b/yapypy/extended_python/parser.py
@@ -3,15 +3,12 @@ from rbnf.core.Tokenizer import Tokenizer
 from rbnf.core.CachingPool import ConstStrPool
 from rbnf.core.State import State
 from rbnf.easy import Language, build_parser, build_language, ze
-from rbnf.edsl.rbnf_analyze import check_parsing_complete
 from keyword import kwlist
 from yapypy.extended_python.grammar import RBNF
 from yapypy.extended_python import helper, extended_ast
 
 import ast
 import typing as t
-import traceback
-import sys
 import io
 cast = ConstStrPool.cast_to_const
 

--- a/yapypy/extended_python/parser.py
+++ b/yapypy/extended_python/parser.py
@@ -6,7 +6,7 @@ from rbnf.easy import Language, build_parser, build_language, ze
 from rbnf.edsl.rbnf_analyze import check_parsing_complete
 from keyword import kwlist
 from yapypy.extended_python.grammar import RBNF
-from yapypy.extended_python import helper
+from yapypy.extended_python import helper, extended_ast
 
 import ast
 import typing as t
@@ -43,7 +43,11 @@ def lex(text: t.Union[str, bytes]):
 
 
 python = Language('python')
-python.namespace.update({**helper.__dict__, **ast.__dict__})
+python.namespace.update({
+    **extended_ast.__dict__,
+    **helper.__dict__,
+    **ast.__dict__
+})
 build_language(RBNF, python, '<grammar>')
 python_parser = python.named_parsers['file_input']
 

--- a/yapypy/extended_python/pybc_emit.py
+++ b/yapypy/extended_python/pybc_emit.py
@@ -1,6 +1,6 @@
 import ast
-import dis
 from typing import NamedTuple
+import yapypy.extended_python.extended_ast as ex_ast
 from yapypy.extended_python.symbol_analyzer import SymTable, Tag
 from yapypy.utils.namedlist import INamedList, as_namedlist, trait
 from yapypy.utils.instrs import *
@@ -56,6 +56,17 @@ class Context(INamedList, metaclass=trait(as_namedlist)):
             self.bc.append(Instr('LOAD_FAST', name, lineno=lineno))
         else:
             self.bc.append(Instr("LOAD_GLOBAL", name, lineno=lineno))
+
+    def del_name(self, name, lineno=None):
+        sym_tb = self.sym_tb
+        if name in sym_tb.cellvars:
+            self.bc.append(Instr('DELETE_DEREF', CellVar(name), lineno=lineno))
+        elif name in sym_tb.freevars:
+            self.bc.append(Instr('DELETE_DEREF', FreeVar(name), lineno=lineno))
+        elif name in sym_tb.bounds:
+            self.bc.append(Instr('DELETE_FAST', name, lineno=lineno))
+        else:
+            self.bc.append(Instr("DELETE_GLOBAL", name, lineno=lineno))
 
     def store_name(self, name, lineno=None):
         sym_tb = self.sym_tb
@@ -229,6 +240,7 @@ def py_emit(node: ast.FunctionDef, new_ctx: Context):
 
     new_ctx.bc.append(Instr('LOAD_CONST', None))
     new_ctx.bc.append(Instr('RETURN_VALUE'))
+    print(new_ctx.bc)
     inner_code = new_ctx.bc.to_code()
 
     parent_ctx.bc.append(Instr('LOAD_CONST', inner_code, lineno=node.lineno))
@@ -242,7 +254,7 @@ def py_emit(node: ast.FunctionDef, new_ctx: Context):
     parent_ctx.store_name(node.name, lineno=node.lineno)
 
 
-@py_emit.case(ast.Dict)
+@py_emit.case(ex_ast.ExDict)
 def py_emit(node: ast.Dict, ctx: Context):
     keys = node.keys
     values = node.values
@@ -268,10 +280,12 @@ def py_emit(node: ast.Assign, ctx: Context):
 
 @py_emit.case(ast.Name)
 def py_emit(node: ast.Name, ctx: Context):
-    if isinstance(node.ctx, ast.Load):
-        ctx.load_name(node.id, lineno=node.lineno)
-    else:
-        ctx.store_name(node.id, lineno=node.lineno)
+    {
+        ast.Load: ctx.load_name,
+        ast.Store: ctx.store_name,
+        ast.Del: ctx.del_name
+    }[type(node.ctx)](
+        node.id, lineno=node.lineno)
 
 
 @py_emit.case(ast.Expr)
@@ -524,15 +538,18 @@ def py_emit(node: ast.Import, ctx: Context):
 @py_emit.case(ast.ImportFrom)
 def py_emit(node: ast.ImportFrom, ctx: Context):
     lineno = node.lineno
+
     ctx.bc.append(Instr("LOAD_CONST", node.level, lineno=lineno))
     names = tuple(name.name for name in node.names)
     ctx.bc.append(LOAD_CONST(names, lineno=lineno))
-
     ctx.bc.append(Instr("IMPORT_NAME", node.module, lineno=lineno))
+
     if names == ('*', ):
         ctx.bc.append(Instr('IMPORT_STAR', lineno=lineno))
+
     else:
         for name in node.names:
+
             ctx.bc.append(Instr("IMPORT_FROM", name.name, lineno=lineno))
             as_name = name.name or name.asname
             ctx.store_name(as_name, lineno=lineno)

--- a/yapypy/extended_python/symbol_analyzer.py
+++ b/yapypy/extended_python/symbol_analyzer.py
@@ -136,8 +136,11 @@ class Tag(ast.AST):
     tag: SymTable
 
     def __init__(self, it, tag):
+        super().__init__()
         self.it = it
         self.tag = tag
+
+    _fields = 'it',
 
 
 def _visit_name(self, node: ast.Name):


### PR DESCRIPTION
`ExDict` has an additional field `ctx`, which makes dict unpacking possible:
```python
{a: 1, b:2, **kwargs} = d

```